### PR TITLE
Rewrite of drainContainers and fillContainers methods

### DIFF
--- a/src/main/java/reborncore/common/util/FluidUtils.java
+++ b/src/main/java/reborncore/common/util/FluidUtils.java
@@ -5,7 +5,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
-import net.minecraftforge.fluids.UniversalBucket;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
@@ -14,60 +13,113 @@ import javax.annotation.Nullable;
 
 public class FluidUtils {
 
-	public static boolean drainContainers(final IFluidHandler fluidHandler, final IInventory inv, final int inputSlot,
-	                                      final int outputSlot) {
-		final ItemStack input = inv.getStackInSlot(inputSlot);
-		final ItemStack output = inv.getStackInSlot(outputSlot);
+    public boolean drainContainers(IFluidHandler fluidHandler, IInventory inv, int inputSlot, int outputSlot) {
+        ItemStack input = inv.getStackInSlot(inputSlot);
+        ItemStack output = inv.getStackInSlot(outputSlot);
 
-		if (input != ItemStack.EMPTY) {
-			final FluidStack fluidInContainer = getFluidStackInContainer(input);
-			ItemStack emptyItem = input.getItem().getContainerItem(input);
-			if (input.getItem() instanceof UniversalBucket) {
-				emptyItem = ((UniversalBucket) input.getItem()).getEmpty();
-			}
+        IFluidHandlerItem inputFluidHandler = getFluidHandler(input);
 
-			if (fluidInContainer != null && (emptyItem == ItemStack.EMPTY || output == ItemStack.EMPTY
-				|| output.getCount() < output.getMaxStackSize()
-				&& ItemUtils.isItemEqual(output, emptyItem, true, true))) {
+        if (inputFluidHandler != null) {
 
-				final int used = fluidHandler.fill(fluidInContainer, false);
-				if (used >= fluidInContainer.amount && fluidHandler.fill(fluidInContainer, true) > 0) {
-					fluidHandler.fill(fluidInContainer, true);
-					if (emptyItem != ItemStack.EMPTY)
-						if (output == ItemStack.EMPTY)
-							inv.setInventorySlotContents(outputSlot, emptyItem);
-						else
-							output.setCount(output.getCount() + 1);
-					inv.decrStackSize(inputSlot, 1);
+            /*
+             * Making a simulation to check if the fluid can be drained into the
+             * fluidhandler.
+             */
+            if (FluidUtil.tryFluidTransfer(fluidHandler, inputFluidHandler,
+                    inputFluidHandler.getTankProperties()[0].getCapacity(), false) != null) {
 
-					return true;
-				}
-			}
-		}
-		return false;
-	}
+                // Changes are really applied and the fluid is drained.
+                FluidStack drained = FluidUtil.tryFluidTransfer(fluidHandler, inputFluidHandler,
+                        inputFluidHandler.getTankProperties()[0].getCapacity(), true);
 
-	public static boolean fillContainers(IFluidHandler fluidHandler, IInventory inv, int inputSlot, int outputSlot,
-	                                     Fluid fluidToFill) {
-		ItemStack input = inv.getStackInSlot(inputSlot);
-		ItemStack output = inv.getStackInSlot(outputSlot);
-		ItemStack filled = getFilledContainer(fluidToFill, input);
-		if ((output == ItemStack.EMPTY
-			|| (output.getCount() < output.getMaxStackSize() && ItemUtils.isItemEqual(filled, output, true, true)))) {
-			FluidStack fluidInContainer = getFluidStackInContainer(filled);
-			FluidStack drain = fluidHandler.drain(fluidInContainer, false);
-			if (drain != null && drain.amount == fluidInContainer.amount) {
-				fluidHandler.drain(fluidInContainer, true);
-				if (output == ItemStack.EMPTY)
-					inv.setInventorySlotContents(outputSlot, filled);
-				else
-					output.setCount(output.getCount() + 1);
-				inv.decrStackSize(inputSlot, 1);
-				return true;
-			}
-		}
-		return false;
-	}
+                /*
+                 * If the drained container doesn't disappear we need to update
+                 * the inventory accordingly.
+                 */
+                if (drained != null && inputFluidHandler.getContainer() != ItemStack.EMPTY)
+                    if (output == ItemStack.EMPTY) {
+                        inv.setInventorySlotContents(outputSlot, inputFluidHandler.getContainer());
+                        inv.decrStackSize(inputSlot, 1);
+                    } else {
+
+                        /*
+                         * When output is not EMPTY, it is needed to check if
+                         * the two stacks can be merged together, there was no
+                         * simple way to make that check before.
+                         */
+                        if (ItemUtils.isItemEqual(output, inputFluidHandler.getContainer(), true, true)) {
+                            inv.getStackInSlot(outputSlot).setCount(inv.getStackInSlot(outputSlot).getCount() + 1);
+                            inv.decrStackSize(inputSlot, 1);
+                        } else {
+
+                            /*
+                             * Due to the late check of stacks merge we need to
+                             * reverse any changes made to the FluidHandlers
+                             * when the merge fail.
+                             */
+                            FluidUtil.tryFluidTransfer(inputFluidHandler, fluidHandler, drained.amount, true);
+                            return false;
+                        }
+                    }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean fillContainers(IFluidHandler fluidHandler, IInventory inv, int inputSlot, int outputSlot,
+            Fluid fluidToFill) {
+        ItemStack input = inv.getStackInSlot(inputSlot);
+        ItemStack output = inv.getStackInSlot(outputSlot);
+
+        if (input != ItemStack.EMPTY) {
+            IFluidHandlerItem inputFluidHandler = getFluidHandler(input);
+
+            /*
+             * The copy is needed to get the filled container without altering
+             * the original ItemStack.
+             */
+            ItemStack containerCopy = input.copy();
+            containerCopy.setCount(1);
+
+            /*
+             * It's necessary to check before any alterations that the resulting
+             * ItemStack can be placed into the outputSlot.
+             */
+            if (inputFluidHandler != null && (output == ItemStack.EMPTY
+                    || (output.getCount() < output.getMaxStackSize() && ItemUtils.isItemEqual(
+                            FluidUtils.getFilledContainer(fluidToFill, containerCopy), output, true, true)))) {
+
+                /*
+                 * Making a simulation to check if the fluid can be transfered
+                 * into the fluidhandler.
+                 */
+                if (FluidUtil.tryFluidTransfer(inputFluidHandler, fluidHandler,
+                        inputFluidHandler.getTankProperties()[0].getCapacity(), false) != null) {
+
+                    // Changes are really applied and the fluid is transfered.
+                    FluidUtil.tryFluidTransfer(inputFluidHandler, fluidHandler,
+                            inputFluidHandler.getTankProperties()[0].getCapacity(), true);
+
+                    // The inventory is modified and stacks are merged.
+                    if (output == ItemStack.EMPTY)
+                        inv.setInventorySlotContents(outputSlot, inputFluidHandler.getContainer());
+                    else
+                        inv.getStackInSlot(outputSlot).setCount(inv.getStackInSlot(outputSlot).getCount() + 1);
+                    inv.decrStackSize(inputSlot, 1);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    
+    @Nullable
+    public IFluidHandlerItem getFluidHandler(ItemStack container) {
+        ItemStack copy = container.copy();
+        copy.setCount(1);
+        return FluidUtil.getFluidHandler(copy);
+    }
 
 	@Nullable
 	public static FluidStack getFluidStackInContainer(


### PR DESCRIPTION
This PR try to fix every misbehaviors of the drainContainers and fillContainers methods **without altering what was expected from them**.

Bugs that have been fixed : 

- It was impossible to drain fluids from a Cell if an **already drained cell** was in the output slot.

- **Twice** the asked amount of fluid was filled.

- It wasn't possible to fill a stack of cells **exceding 1 of stacksize** from a TechReborn tank.

- It wasn't possible to fill a **vanilla bucket**.

- When draining Cells were **disappearing** if a different container was already in the outputSlot.

It's important to note that due to the nature of the drainContainers method a FluidContainer that do apply some modifications to himself **upon draining** might be altered by the checks because a real draining **must occur** to retrieve the drained ItemStack. At this time **I haven't found** a good solution to that case scenario.

The PR also add a **small utility method** that allow to retrieve the FluidHandler safely by duplicating the ItemStack.