### PR TITLE
Tesla fixes

### DIFF
--- a/src/main/java/reborncore/common/powerSystem/tesla/AdvancedTeslaContainer.java
+++ b/src/main/java/reborncore/common/powerSystem/tesla/AdvancedTeslaContainer.java
@@ -30,12 +30,26 @@ public class AdvancedTeslaContainer implements ITeslaConsumer, ITeslaHolder, ITe
 
 	//Receive
 	public long givePower(long tesla, boolean simulated) {
-		return (long) tile.addEnergy(tesla * RebornCoreConfig.euPerFU);
+		double euToAdd = tesla * RebornCoreConfig.euPerFU;
+
+		if (tile.canAddEnergy(euToAdd)) {
+			double euAdded = tile.addEnergy(euToAdd);
+			return (long) (euAdded / RebornCoreConfig.euPerFU);
+		} else {
+			return 0;
+		}
 	}
 
 	//Take power out
 	public long takePower(long tesla, boolean simulated) {
-		return (int) tile.useEnergy(tesla * RebornCoreConfig.euPerFU);
+		double euToTake = tesla * RebornCoreConfig.euPerFU;
+
+		if (tile.canUseEnergy(euToTake)) {
+			double euTaken = tile.useEnergy(euToTake);
+			return (long) (euTaken / RebornCoreConfig.euPerFU);
+		} else {
+			return 0;
+		}
 	}
 
 	public long getCapacity() {

--- a/src/main/java/reborncore/common/powerSystem/tesla/TeslaPowerManager.java
+++ b/src/main/java/reborncore/common/powerSystem/tesla/TeslaPowerManager.java
@@ -1,5 +1,6 @@
 package reborncore.common.powerSystem.tesla;
 
+import net.darkhax.tesla.api.ITeslaConsumer;
 import net.darkhax.tesla.capability.TeslaCapabilities;
 import net.darkhax.tesla.lib.TeslaUtils;
 import net.minecraft.nbt.NBTTagCompound;
@@ -7,6 +8,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import reborncore.common.RebornCoreConfig;
 import reborncore.common.powerSystem.TilePowerAcceptor;
+
+import java.util.List;
 
 /**
  * Created by modmuss50 on 06/05/2016.
@@ -56,7 +59,15 @@ public class TeslaPowerManager implements ITeslaPowerManager {
 	@Override
 	public void update(TilePowerAcceptor powerAcceptor) {
 		if (powerAcceptor.canProvideEnergy(null)) {
-			TeslaUtils.distributePowerToAllFaces(powerAcceptor.getWorld(), powerAcceptor.getPos(), (long) powerAcceptor.getMaxOutput(), false);
+			List<ITeslaConsumer> connectedConsumers = TeslaUtils.getConnectedCapabilities(TeslaCapabilities.CAPABILITY_CONSUMER, powerAcceptor.getWorld(), powerAcceptor.getPos());
+
+			for (ITeslaConsumer consumer : connectedConsumers) {
+				double euToTransfer = Math.min(powerAcceptor.getEnergy(), powerAcceptor.getMaxOutput());
+				long teslaTransferred = consumer.givePower((long) (euToTransfer / RebornCoreConfig.euPerFU), false);
+				powerAcceptor.useEnergy(teslaTransferred * RebornCoreConfig.euPerFU);
+
+				if (powerAcceptor.getEnergy() <= 0) break;
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes TechReborn/TechReborn#978. Some notes:

- The second commit changes the Tesla behaviour to check whether a machine can accept some amount of energy that is being transferred into it. This means that if a machine has, say, 900 T stored out of 1000 T max (or, rather, the respective amounts in EU), and some other machine attempts to transfer 128 T into it, the transfer will fail instead of just transferring 100 T. This matches the EU behaviour found in `update` in `TilePowerAcceptor`, but it doesn't seem like a good idea to me; what if a small machine has a storage of 1000 T and a large machine that always transfers 3000 T at once attempts to power it? It would never get any power even though it should.
- I encountered some other possible problems while browsing through the code, but I might have overlooked something, so I didn't include them in here:
  - In `useEnergy` in `TilePowerAcceptor`, the energy is sometimes set even if `simulate` is `true`: [Line 284](https://github.com/TechReborn/RebornCore/blob/1.11.2/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java#L284)
  - In `addEnergy`, `getMaxPower` is checked for twice (maybe `getMaxOutput` was meant instead?) [Line 262](https://github.com/TechReborn/RebornCore/blob/1.11.2/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java#L262)
- I have tested the changes a bit, but not really extensively; there might be some edge case I haven't noticed that is broken now, so you guys should probably test this as well.