### PR TITLE
Fix several issues related to energy flow

### DIFF
--- a/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
+++ b/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
@@ -292,13 +292,7 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 
 	@Override
 	public void setEnergy(double energy) {
-		this.energy = energy;
-
-		if (this.getEnergy() > getMaxPower()) {
-			this.setEnergy(getMaxPower());
-		} else if (this.energy < 0) {
-			this.setEnergy(0);
-		}
+		this.energy = Math.max(Math.min(energy, getMaxPower()), 0);
 	}
 
 	@Override

--- a/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
+++ b/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
@@ -239,7 +239,7 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 	}
 	// END IC2
 
-	// Old cofh stuff, still used in places internaly, should be removed at somepoint
+	// Old cofh stuff, still used to implement Forge Energy, should be removed at somepoint
 	@Deprecated
 	public boolean canConnectEnergy(EnumFacing from) {
 		return canAcceptEnergy(from) || canProvideEnergy(from);
@@ -275,13 +275,13 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 		if (!canProvideEnergy(from)) {
 			return 0;
 		}
-		maxExtract *= RebornCoreConfig.euPerFU;
-		int energyExtracted = Math.min(getEnergyStored(null), maxExtract);
+		int euExtracted = Math.min(getEnergyStored(null), maxExtract / RebornCoreConfig.euPerFU);
+		int feExtracted = euExtracted * RebornCoreConfig.euPerFU;
 
 		if (!simulate) {
-			setEnergy(getEnergy() - energyExtracted);
+			setEnergy(getEnergy() - euExtracted);
 		}
-		return energyExtracted / RebornCoreConfig.euPerFU;
+		return feExtracted;
 	}
 	// END COFH
 

--- a/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
+++ b/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
@@ -133,7 +133,7 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 					} else if (tile.hasCapability(CapabilityEnergy.ENERGY, side.getOpposite())) {
 						IEnergyStorage energyStorage = tile.getCapability(CapabilityEnergy.ENERGY, side.getOpposite());
 						if (forgePowerManager != null && energyStorage != null && energyStorage.canReceive() && this.canProvideEnergy(side)) {
-							int drain = forgePowerManager.extractEnergy(Math.min(forgePowerManager.getEnergyStored(), (int) getMaxOutput() / RebornCoreConfig.euPerFU), true);
+							int drain = forgePowerManager.extractEnergy(Math.min(forgePowerManager.getEnergyStored(), (int) getMaxOutput() * RebornCoreConfig.euPerFU), true);
 							if (drain > 0) {
 								int filled = energyStorage.receiveEnergy(drain, false);
 								forgePowerManager.extractEnergy(filled, false);
@@ -250,12 +250,14 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 		if (!canAcceptEnergy(from)) {
 			return 0;
 		}
-		int energyReceived = (int) Math.min(getMaxEnergyStored(from) - getEnergyStored(from), Math.min(getMaxInput() * RebornCoreConfig.euPerFU, maxReceive));
+		int feReceived = (int) Math.min(getMaxEnergyStored(from) - getEnergyStored(from), Math.min(getMaxInput() * RebornCoreConfig.euPerFU, maxReceive));
+		int euReceived = feReceived / RebornCoreConfig.euPerFU;
+		feReceived = euReceived * RebornCoreConfig.euPerFU;
 
 		if (!simulate) {
-			setEnergy(getEnergy() + energyReceived);
+			setEnergy(getEnergy() + euReceived);
 		}
-		return energyReceived;
+		return feReceived;
 	}
 
 	@Deprecated

--- a/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
+++ b/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
@@ -329,9 +329,7 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 	@Override
 	public double useEnergy(double extract, boolean simulate) {
 		if (extract > energy) {
-			double tempEnergy = energy;
-			setEnergy(0);
-			return tempEnergy;
+			extract = energy;
 		}
 		if (!simulate) {
 			setEnergy(energy - extract);


### PR DESCRIPTION
TilePowerAcceptor now handles FE/EU conversions correctly, and does not delete energy in simulation mode.

In particular, this fixes problems such as a Generator connected through a Battery Box and some cables to an Electric Furnace showing the Battery Box losing all of its stored energy, despite the Generator producing more power than the Furnace uses.