### PR TITLE
Make FE support in TIlePowerAcceptor a ForgePowerHandler

### DIFF
--- a/src/main/java/reborncore/common/RebornCoreConfig.java
+++ b/src/main/java/reborncore/common/RebornCoreConfig.java
@@ -40,6 +40,9 @@ public class RebornCoreConfig {
 	@ConfigRegistry(config = "power", key = "EU - FU ratio", comment = "The Amount of FU to output from EU")
 	public static int euPerFU = 4;
 
+	@ConfigRegistry(config = "power", key = "Enable FE support", comment = "Whether energy blocks will accept and emit Forge Energy (FE/RF/etc)")
+	public static boolean enableFE = true;
+
 	@ConfigRegistry(config = "client", key = "Show Stack Info HUD", comment = "Show Stack Info HUD")
 	public static boolean ShowStackInfoHUD = true;
 

--- a/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
+++ b/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
@@ -73,15 +73,15 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 	}
 
 	private void setupManagers(){
-		ForgePowerHandler forgePowerHandler = new ForgePowerHandler(this);
-
 		final TilePowerAcceptor tile = this;
 		powerManagers = ExternalPowerSystems.externalPowerHandlerList.stream()
 			.map(externalPowerManager -> externalPowerManager.createPowerHandler(tile))
 			.filter(Objects::nonNull)
 			.collect(Collectors.toList());
 
-		powerManagers.add(0, forgePowerHandler);
+		if(RebornCoreConfig.enableFE) {
+			powerManagers.add(0, new ForgePowerHandler(this));
+		}
 	}
 
 

--- a/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
+++ b/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
@@ -30,24 +30,19 @@ package reborncore.common.powerSystem;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import reborncore.api.IListInfoProvider;
 import reborncore.api.power.*;
 import reborncore.common.RebornCoreConfig;
-import reborncore.common.powerSystem.forge.ForgePowerManager;
+import reborncore.common.powerSystem.forge.ForgePowerHandler;
 import reborncore.common.tile.TileLegacyMachineBase;
 import reborncore.common.util.StringUtils;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -55,7 +50,6 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 	IEnergyInterfaceTile, IListInfoProvider // TechReborn
 {
 	private EnumPowerTier tier;
-	ForgePowerManager forgePowerManager = new ForgePowerManager(this, null);
 	private double energy;
 
 	public double extraPowerStoage;
@@ -65,23 +59,23 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 	public double powerLastTick;
 	public boolean checkOverfill = true; //Set to flase to disable the overfill check.
 
-	List<ExternalPowerHandler> powerManagers;
+	private ForgePowerHandler forgePowerHandler;
+	private List<ExternalPowerHandler> powerManagers;
 
 	public TilePowerAcceptor() {
-		checkTeir();
-		final TilePowerAcceptor tile = this;
-		powerManagers = ExternalPowerSystems.externalPowerHandlerList.stream()
-			.map(externalPowerManager -> externalPowerManager.createPowerHandler(tile))
-			.collect(Collectors.toList());
-	}
-
-	public TilePowerAcceptor(EnumPowerTier tier) {
 		checkTeir();
 		setupManagers();
 	}
 
+	// don't manually set tiers
+	@Deprecated
+	public TilePowerAcceptor(EnumPowerTier tier) {
+		this();
+	}
 
 	private void setupManagers(){
+		forgePowerHandler = new ForgePowerHandler(this);
+
 		final TilePowerAcceptor tile = this;
 		powerManagers = ExternalPowerSystems.externalPowerHandlerList.stream()
 			.map(externalPowerManager -> externalPowerManager.createPowerHandler(tile))
@@ -180,65 +174,7 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 		}
 
 		powerManagers.forEach(ExternalPowerHandler::tick);
-		
-		Map<EnumFacing, TileEntity> acceptors = new HashMap<EnumFacing, TileEntity>();
-		if (getEnergy() > 0) { // Tesla or IC2 should handle this if enabled, so only do this without tesla
-			for (EnumFacing side : EnumFacing.values()) {
-				if (canProvideEnergy(side)) {
-					TileEntity tile = world.getTileEntity(pos.offset(side));
-					if (tile == null) {
-						continue;
-					} else if (ExternalPowerSystems.isPoweredTile(tile)) {
-						//Other power net will take care about this
-						continue;
-					} else if (tile instanceof IEnergyInterfaceTile) {
-						IEnergyInterfaceTile eFace = (IEnergyInterfaceTile) tile;
-						if (eFace.canAcceptEnergy(side.getOpposite())) {
-							acceptors.put(side, tile);
-						}
-					} else if (tile.hasCapability(CapabilityEnergy.ENERGY, side.getOpposite())) {
-						acceptors.put(side, tile);
-					}
-				}
-			}
-		}
-
-		if (acceptors.size() > 0) {
-			double drain = useEnergy(Math.min(getEnergy(), getMaxOutput()), true);
-			double energyShare = drain / acceptors.size();
-			double remainingEnergy = drain;
-
-			if (energyShare > 0) {
-				for (Map.Entry<EnumFacing, TileEntity> entry : acceptors.entrySet()) {
-					EnumFacing side = entry.getKey();
-					TileEntity tile = entry.getValue();
-					if (tile instanceof IEnergyInterfaceTile) {
-						IEnergyInterfaceTile eFace = (IEnergyInterfaceTile) tile;
-						if (RebornCoreConfig.smokeHighTeir && handleTierWithPower() && (eFace.getTier().ordinal() < getPushingTier().ordinal())) {
-							for (int j = 0; j < 2; ++j) {
-								double d3 = (double) pos.getX() + world.rand.nextDouble()
-										+ (side.getFrontOffsetX() / 2);
-								double d8 = (double) pos.getY() + world.rand.nextDouble() + 1;
-								double d13 = (double) pos.getZ() + world.rand.nextDouble()
-										+ (side.getFrontOffsetZ() / 2);							
-								((WorldServer) world).spawnParticle(EnumParticleTypes.SMOKE_LARGE, false, d3, d8, d13, 2, 0.0D, 0.0D, 0.0D, 0.0D);
-							}
-						} else {
-							double filled = eFace.addEnergy(Math.min(energyShare, remainingEnergy), false);
-							remainingEnergy -= useEnergy(filled, false);
-						}
-					} else if (tile.hasCapability(CapabilityEnergy.ENERGY, side.getOpposite())) {
-						IEnergyStorage energyStorage = tile.getCapability(CapabilityEnergy.ENERGY, side.getOpposite());
-						if (forgePowerManager != null && energyStorage != null && energyStorage.canReceive()
-								&& this.canProvideEnergy(side)) {
-							int filled = energyStorage.receiveEnergy(
-									(int) Math.min(energyShare, remainingEnergy) * RebornCoreConfig.euPerFU, false);
-							remainingEnergy -= useEnergy(filled / RebornCoreConfig.euPerFU, false);
-						}
-					}
-				}
-			}
-		}
+		forgePowerHandler.tick();
 
 		powerChange = getEnergy() - powerLastTick;
 		powerLastTick = getEnergy();
@@ -271,9 +207,10 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 	
 	@Override
 	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
-		if (capability == CapabilityEnergy.ENERGY && (canAcceptEnergy(facing) || canProvideEnergy(facing))) {
+		if(forgePowerHandler.hasCapability(capability, facing)) {
 			return true;
 		}
+
 		if(powerManagers.stream().filter(Objects::nonNull).anyMatch(externalPowerHandler -> externalPowerHandler.hasCapability(capability, facing))) {
 			return true;
 		}
@@ -282,12 +219,10 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 
 	@Override
 	public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
-		if (capability == CapabilityEnergy.ENERGY && (canAcceptEnergy(facing) || canProvideEnergy(facing))) {
-			if (forgePowerManager == null) {
-				forgePowerManager = new ForgePowerManager(this, facing);
-			}
-			forgePowerManager.setFacing(facing);
-			return CapabilityEnergy.ENERGY.cast(forgePowerManager);
+		T internalCap = forgePowerHandler.getCapability(capability, facing);
+
+		if(internalCap != null) {
+			return internalCap;
 		}
 
 		T externalCap = powerManagers.stream()
@@ -319,12 +254,16 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 	@Override
 	public void invalidate() {
 		super.invalidate();
+
+		forgePowerHandler.invalidate();
 		powerManagers.forEach(ExternalPowerHandler::invalidate);
 	}
 
 	@Override
 	public void onChunkUnload() {
 		super.onChunkUnload();
+
+		forgePowerHandler.unload();
 		powerManagers.forEach(ExternalPowerHandler::unload);
 	}
 	

--- a/src/main/java/reborncore/common/powerSystem/forge/ForgePowerHandler.java
+++ b/src/main/java/reborncore/common/powerSystem/forge/ForgePowerHandler.java
@@ -1,0 +1,125 @@
+package reborncore.common.powerSystem.forge;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumParticleTypes;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.IEnergyStorage;
+import reborncore.api.power.ExternalPowerHandler;
+import reborncore.api.power.IEnergyInterfaceTile;
+import reborncore.common.RebornCoreConfig;
+import reborncore.common.powerSystem.ExternalPowerSystems;
+import reborncore.common.powerSystem.TilePowerAcceptor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ForgePowerHandler implements ExternalPowerHandler {
+	TilePowerAcceptor powerAcceptor;
+	ForgePowerManager powerManager;
+
+	public ForgePowerHandler(TilePowerAcceptor powerAcceptor) {
+		this.powerAcceptor = powerAcceptor;
+		this.powerManager = new ForgePowerManager(powerAcceptor, null);
+	}
+
+	public void tick() {
+		Map<EnumFacing, TileEntity> acceptors = new HashMap<EnumFacing, TileEntity>();
+		if (powerAcceptor.getEnergy() > 0) { // Tesla or IC2 should handle this if enabled, so only do this without tesla
+			for (EnumFacing side : EnumFacing.values()) {
+				if (powerAcceptor.canProvideEnergy(side)) {
+					TileEntity tile = powerAcceptor.getWorld().getTileEntity(powerAcceptor.getPos().offset(side));
+					if (tile == null) {
+						continue;
+					} else if (ExternalPowerSystems.isPoweredTile(tile)) {
+						// NB: This means we can't register ForgePowerHandler in the ExternalPowerSystems list
+						// NB: Otherwise the check will not work.
+
+						// Other power net will take care about this
+						continue;
+					} else if (tile instanceof IEnergyInterfaceTile) {
+						IEnergyInterfaceTile eFace = (IEnergyInterfaceTile) tile;
+						if (eFace.canAcceptEnergy(side.getOpposite())) {
+							acceptors.put(side, tile);
+						}
+					} else if (tile.hasCapability(CapabilityEnergy.ENERGY, side.getOpposite())) {
+						acceptors.put(side, tile);
+					}
+				}
+			}
+		}
+
+		if (acceptors.size() > 0) {
+			double drain = powerAcceptor.useEnergy(Math.min(powerAcceptor.getEnergy(), powerAcceptor.getMaxOutput()), true);
+			double energyShare = drain / acceptors.size();
+			double remainingEnergy = drain;
+
+			if (energyShare > 0) {
+				for (Map.Entry<EnumFacing, TileEntity> entry : acceptors.entrySet()) {
+					EnumFacing side = entry.getKey();
+					TileEntity tile = entry.getValue();
+					if (tile instanceof IEnergyInterfaceTile) {
+						IEnergyInterfaceTile eFace = (IEnergyInterfaceTile) tile;
+						if (RebornCoreConfig.smokeHighTeir && powerAcceptor.handleTierWithPower() && (eFace.getTier().ordinal() < powerAcceptor.getPushingTier().ordinal())) {
+
+							World world = powerAcceptor.getWorld();
+							BlockPos pos = powerAcceptor.getPos();
+
+							for (int j = 0; j < 2; ++j) {
+								double d3 = (double) pos.getX() + world.rand.nextDouble()
+										+ (side.getFrontOffsetX() / 2);
+								double d8 = (double) pos.getY() + world.rand.nextDouble() + 1;
+								double d13 = (double) pos.getZ() + world.rand.nextDouble()
+										+ (side.getFrontOffsetZ() / 2);
+								((WorldServer) world).spawnParticle(EnumParticleTypes.SMOKE_LARGE, false, d3, d8, d13, 2, 0.0D, 0.0D, 0.0D, 0.0D);
+							}
+						} else {
+							double filled = eFace.addEnergy(Math.min(energyShare, remainingEnergy), false);
+							remainingEnergy -= powerAcceptor.useEnergy(filled, false);
+						}
+					} else if (tile.hasCapability(CapabilityEnergy.ENERGY, side.getOpposite())) {
+						IEnergyStorage energyStorage = tile.getCapability(CapabilityEnergy.ENERGY, side.getOpposite());
+						if (powerManager != null && energyStorage != null && energyStorage.canReceive()
+								&& powerAcceptor.canProvideEnergy(side)) {
+							int filled = energyStorage.receiveEnergy(
+									(int) Math.min(energyShare, remainingEnergy) * RebornCoreConfig.euPerFU, false);
+							remainingEnergy -= powerAcceptor.useEnergy(filled / RebornCoreConfig.euPerFU, false);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	public void unload() {
+
+	}
+
+	public void invalidate() {
+
+	}
+
+	@Override
+	public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
+		return capability == CapabilityEnergy.ENERGY && (powerAcceptor.canAcceptEnergy(facing) || powerAcceptor.canProvideEnergy(facing));
+	}
+
+	@Nullable @Override
+	public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
+		if (capability == CapabilityEnergy.ENERGY && (powerAcceptor.canAcceptEnergy(facing) || powerAcceptor.canProvideEnergy(facing))) {
+			if (powerManager == null) {
+				powerManager = new ForgePowerManager(powerAcceptor, facing);
+			}
+			powerManager.setFacing(facing);
+			return CapabilityEnergy.ENERGY.cast(powerManager);
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/reborncore/common/powerSystem/forge/ForgePowerHandler.java
+++ b/src/main/java/reborncore/common/powerSystem/forge/ForgePowerHandler.java
@@ -1,3 +1,31 @@
+/*
+ * Copyright (c) 2018 modmuss50 and Gigabit101
+ *
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package reborncore.common.powerSystem.forge;
 
 import net.minecraft.tileentity.TileEntity;


### PR DESCRIPTION
This is the first in a series of pull requests that is intended to improve the support of the various available power systems in Reborn Core (and by extension Tech Reborn). In this pull request, FE support in TilePowerAcceptor is separated into an ExternalPowerHandler, making FE support work the same way as EU support.

Not only does this make the power support more modular, as FE is no longer a special case (at least on the block level), it also makes the configuration option for disabling FE much more logical: instead of a range of statements across the class, adding/removing FE support from a TilePowerAcceptor is now a single line.

Once/if this is merged, https://github.com/TechReborn/TechReborn/issues/1640 can be considered fixed. However, I will make further pull requests focused on allowing items to support IC2 EU better, which will finally allow TR items to be charged by IC2, as well as allow the disabling of FE support for items (allowing https://github.com/TechReborn/TechReborn/issues/1625 to be fixed).