### PR TITLE
Completely move FE support to an ExternalPowerManager, removing the special case

### DIFF
--- a/src/main/java/reborncore/api/power/ExternalPowerManager.java
+++ b/src/main/java/reborncore/api/power/ExternalPowerManager.java
@@ -32,6 +32,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import reborncore.common.powerSystem.TilePowerAcceptor;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 
 public interface ExternalPowerManager {
 
@@ -42,7 +43,8 @@ public interface ExternalPowerManager {
 	public boolean isPoweredTile(TileEntity tileEntity, EnumFacing side);
 
 	public void dischargeItem(TilePowerAcceptor tilePowerAcceptor, ItemStack stack);
+	public void dischargeItem(ForgePowerItemManager powerAcceptor, ItemStack stack);
 
 	public void chargeItem(TilePowerAcceptor tilePowerAcceptor, ItemStack stack);
-
+	public void chargeItem(ForgePowerItemManager powerAcceptor, ItemStack stack);
 }

--- a/src/main/java/reborncore/api/power/ExternalPowerManager.java
+++ b/src/main/java/reborncore/api/power/ExternalPowerManager.java
@@ -28,6 +28,7 @@
 
 package reborncore.api.power;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -43,8 +44,15 @@ public interface ExternalPowerManager {
 	public boolean isPoweredTile(TileEntity tileEntity, EnumFacing side);
 
 	public void dischargeItem(TilePowerAcceptor tilePowerAcceptor, ItemStack stack);
-	public void dischargeItem(ForgePowerItemManager powerAcceptor, ItemStack stack);
 
 	public void chargeItem(TilePowerAcceptor tilePowerAcceptor, ItemStack stack);
 	public void chargeItem(ForgePowerItemManager powerAcceptor, ItemStack stack);
+
+	/**
+	 * Requests that the specified power acceptor be charged from the armor slots in the player's inventory.
+	 *
+	 * @param powerAcceptor The item requesting to be charged
+	 * @param player The player whose inventory contains the power acceptor
+	 */
+	default void requestEnergyFromArmor(ForgePowerItemManager powerAcceptor, EntityPlayer player) { }
 }

--- a/src/main/java/reborncore/client/containerBuilder/builder/ContainerTileInventoryBuilder.java
+++ b/src/main/java/reborncore/client/containerBuilder/builder/ContainerTileInventoryBuilder.java
@@ -89,8 +89,7 @@ public class ContainerTileInventoryBuilder {
 
 	public ContainerTileInventoryBuilder energySlot(final int index, final int x, final int y) {
 		this.parent.slots.add(new FilteredSlot(this.tile, index, x, y)
-			.setFilter(stack -> stack.hasCapability(CapabilityEnergy.ENERGY, EnumFacing.UP)
-				|| ExternalPowerSystems.isPoweredItem(stack)));
+			.setFilter(ExternalPowerSystems::isPoweredItem));
 		return this;
 	}
 

--- a/src/main/java/reborncore/client/hud/StackInfoHUD.java
+++ b/src/main/java/reborncore/client/hud/StackInfoHUD.java
@@ -38,6 +38,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
@@ -46,6 +47,7 @@ import org.lwjgl.opengl.GL11;
 import reborncore.api.power.IEnergyItemInfo;
 import reborncore.common.RebornCoreConfig;
 import reborncore.common.powerSystem.PowerSystem;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 import reborncore.common.util.StringUtils;
 
 import java.util.ArrayList;
@@ -132,8 +134,11 @@ public class StackInfoHUD {
 			
 		String text = "";
 		if (stack.getItem() instanceof IEnergyItemInfo) {
-			int maxCharge = stack.getCapability(CapabilityEnergy.ENERGY, null).getMaxEnergyStored();
-			int currentCharge = stack.getCapability(CapabilityEnergy.ENERGY, null).getEnergyStored();
+			IEnergyStorage capEnergy = new ForgePowerItemManager(stack);
+
+			int maxCharge = capEnergy.getMaxEnergyStored();
+			int currentCharge = capEnergy.getEnergyStored();
+
 			TextFormatting color = TextFormatting.GREEN;
 			double quarter = maxCharge / 4;
 			double half = maxCharge / 2;

--- a/src/main/java/reborncore/common/powerSystem/ExternalPowerSystems.java
+++ b/src/main/java/reborncore/common/powerSystem/ExternalPowerSystems.java
@@ -30,6 +30,7 @@ package reborncore.common.powerSystem;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 import reborncore.RebornCore;
 import reborncore.api.power.ExternalPowerManager;
 import reborncore.common.registration.IRegistryFactory;
@@ -59,8 +60,8 @@ public class ExternalPowerSystems implements IRegistryFactory {
 		externalPowerHandlerList.forEach(externalPowerManager -> externalPowerManager.chargeItem(tilePowerAcceptor, stack));
 	}
 
-	public static boolean isPoweredTile(TileEntity tileEntity){
-		return externalPowerHandlerList.stream().anyMatch(externalPowerManager -> externalPowerManager.isPoweredTile(tileEntity));
+	public static boolean isPoweredTile(TileEntity tileEntity, EnumFacing facing) {
+		return externalPowerHandlerList.stream().anyMatch(externalPowerManager -> externalPowerManager.isPoweredTile(tileEntity, facing));
 	}
 
 	@Override

--- a/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
+++ b/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
@@ -33,12 +33,9 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.energy.CapabilityEnergy;
-import net.minecraftforge.energy.IEnergyStorage;
 import reborncore.api.IListInfoProvider;
 import reborncore.api.power.*;
 import reborncore.common.RebornCoreConfig;
-import reborncore.common.powerSystem.forge.ForgePowerHandler;
 import reborncore.common.tile.TileLegacyMachineBase;
 import reborncore.common.util.StringUtils;
 
@@ -78,10 +75,6 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 			.map(externalPowerManager -> externalPowerManager.createPowerHandler(tile))
 			.filter(Objects::nonNull)
 			.collect(Collectors.toList());
-
-		if(RebornCoreConfig.enableFE) {
-			powerManagers.add(0, new ForgePowerHandler(this));
-		}
 	}
 
 
@@ -112,21 +105,18 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 		if (world.isRemote) {
 			return;
 		}
+
 		double chargeEnergy = Math.min(getFreeSpace(), getMaxInput());
 		if (chargeEnergy <= 0.0 ) {
 			return;
 		}
+
 		ItemStack batteryStack = getStackInSlot(slot);
 		if (batteryStack.isEmpty()) {
 			return;
 		}
-		if (batteryStack.hasCapability(CapabilityEnergy.ENERGY, null)) {
-			IEnergyStorage batteryEnergy = batteryStack.getCapability(CapabilityEnergy.ENERGY, null);
-			if (batteryEnergy.getEnergyStored() > 0) {
-				int extracted = batteryEnergy.extractEnergy((int) (chargeEnergy * RebornCoreConfig.euPerFU), false);
-				addEnergy( extracted / RebornCoreConfig.euPerFU);
-			}
-		} else if (ExternalPowerSystems.isPoweredItem(batteryStack)) {
+
+		if (ExternalPowerSystems.isPoweredItem(batteryStack)) {
 			ExternalPowerSystems.dischargeItem(this, batteryStack);
 		}
 

--- a/src/main/java/reborncore/common/powerSystem/forge/ForgeEnergyStorage.java
+++ b/src/main/java/reborncore/common/powerSystem/forge/ForgeEnergyStorage.java
@@ -26,23 +26,60 @@
  * THE SOFTWARE.
  */
 
-package reborncore.api.power;
+package reborncore.common.powerSystem.forge;
 
-import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraftforge.energy.IEnergyStorage;
 import reborncore.common.powerSystem.TilePowerAcceptor;
 
-public interface ExternalPowerManager {
+import javax.annotation.Nullable;
 
-	public ExternalPowerHandler createPowerHandler(TilePowerAcceptor acceptor);
+public class ForgeEnergyStorage implements IEnergyStorage {
 
-	public boolean isPoweredItem(ItemStack stack);
+	TilePowerAcceptor acceptor;
+	@Nullable
+	EnumFacing facing;
 
-	public boolean isPoweredTile(TileEntity tileEntity, EnumFacing side);
+	public ForgeEnergyStorage(TilePowerAcceptor acceptor,
+	                          @Nullable
+		                         EnumFacing facing) {
+		this.acceptor = acceptor;
+		this.facing = facing;
+	}
 
-	public void dischargeItem(TilePowerAcceptor tilePowerAcceptor, ItemStack stack);
+	@Override
+	public int receiveEnergy(int maxReceive, boolean simulate) {
+		return acceptor.receiveEnergy(facing, maxReceive, simulate);
+	}
 
-	public void chargeItem(TilePowerAcceptor tilePowerAcceptor, ItemStack stack);
+	@Override
+	public int extractEnergy(int maxExtract, boolean simulate) {
+		return acceptor.extractEnergy(facing, maxExtract, simulate);
+	}
 
+	@Override
+	public int getEnergyStored() {
+		return acceptor.getEnergyStored(facing);
+	}
+
+	@Override
+	public int getMaxEnergyStored() {
+		return acceptor.getMaxEnergyStored(facing);
+	}
+
+	@Override
+	public boolean canExtract() {
+		return acceptor.canProvideEnergy(facing);
+	}
+
+	@Override
+	public boolean canReceive() {
+		return acceptor.canAcceptEnergy(facing);
+	}
+
+	public void setFacing(
+		@Nullable
+			EnumFacing facing) {
+		this.facing = facing;
+	}
 }

--- a/src/main/java/reborncore/common/powerSystem/forge/ForgePowerHandler.java
+++ b/src/main/java/reborncore/common/powerSystem/forge/ForgePowerHandler.java
@@ -67,6 +67,7 @@ public class ForgePowerHandler implements ExternalPowerHandler {
 						continue;
 					} else if (isOtherPoweredTile(tile, side.getOpposite())) {
 						// Other power net will take care about this
+
 						continue;
 					} else if (tile instanceof IEnergyInterfaceTile) {
 						IEnergyInterfaceTile eFace = (IEnergyInterfaceTile) tile;
@@ -153,7 +154,7 @@ public class ForgePowerHandler implements ExternalPowerHandler {
 	 */
 	private static boolean isOtherPoweredTile(TileEntity tileEntity, EnumFacing facing) {
 		return ExternalPowerSystems.externalPowerHandlerList.stream()
-				.filter(externalPowerManager -> !(externalPowerManager instanceof ForgePowerHandler))
+				.filter(externalPowerManager -> !(externalPowerManager instanceof ForgePowerManager))
 				.anyMatch(externalPowerManager -> externalPowerManager.isPoweredTile(tileEntity, facing));
 	}
 }

--- a/src/main/java/reborncore/common/powerSystem/forge/ForgePowerHandler.java
+++ b/src/main/java/reborncore/common/powerSystem/forge/ForgePowerHandler.java
@@ -50,11 +50,11 @@ import java.util.Map;
 
 public class ForgePowerHandler implements ExternalPowerHandler {
 	TilePowerAcceptor powerAcceptor;
-	ForgePowerManager powerManager;
+	ForgeEnergyStorage powerManager;
 
 	public ForgePowerHandler(TilePowerAcceptor powerAcceptor) {
 		this.powerAcceptor = powerAcceptor;
-		this.powerManager = new ForgePowerManager(powerAcceptor, null);
+		this.powerManager = new ForgeEnergyStorage(powerAcceptor, null);
 	}
 
 	public void tick() {
@@ -65,10 +65,7 @@ public class ForgePowerHandler implements ExternalPowerHandler {
 					TileEntity tile = powerAcceptor.getWorld().getTileEntity(powerAcceptor.getPos().offset(side));
 					if (tile == null) {
 						continue;
-					} else if (ExternalPowerSystems.isPoweredTile(tile)) {
-						// NB: This means we can't register ForgePowerHandler in the ExternalPowerSystems list
-						// NB: Otherwise the check will not work.
-
+					} else if (isOtherPoweredTile(tile, side.getOpposite())) {
 						// Other power net will take care about this
 						continue;
 					} else if (tile instanceof IEnergyInterfaceTile) {
@@ -142,12 +139,21 @@ public class ForgePowerHandler implements ExternalPowerHandler {
 	public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
 		if (capability == CapabilityEnergy.ENERGY && (powerAcceptor.canAcceptEnergy(facing) || powerAcceptor.canProvideEnergy(facing))) {
 			if (powerManager == null) {
-				powerManager = new ForgePowerManager(powerAcceptor, facing);
+				powerManager = new ForgeEnergyStorage(powerAcceptor, facing);
 			}
 			powerManager.setFacing(facing);
 			return CapabilityEnergy.ENERGY.cast(powerManager);
 		}
 
 		return null;
+	}
+
+	/**
+	 * Checks whether the provided tile is considered a powered tile by other power systems already
+	 */
+	private static boolean isOtherPoweredTile(TileEntity tileEntity, EnumFacing facing) {
+		return ExternalPowerSystems.externalPowerHandlerList.stream()
+				.filter(externalPowerManager -> !(externalPowerManager instanceof ForgePowerHandler))
+				.anyMatch(externalPowerManager -> externalPowerManager.isPoweredTile(tileEntity, facing));
 	}
 }

--- a/src/main/java/reborncore/common/powerSystem/forge/ForgePowerManager.java
+++ b/src/main/java/reborncore/common/powerSystem/forge/ForgePowerManager.java
@@ -28,58 +28,80 @@
 
 package reborncore.common.powerSystem.forge;
 
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
+import reborncore.api.power.ExternalPowerHandler;
+import reborncore.api.power.ExternalPowerManager;
+import reborncore.common.RebornCoreConfig;
 import reborncore.common.powerSystem.TilePowerAcceptor;
+import reborncore.common.registration.RebornRegistry;
 
-import javax.annotation.Nullable;
+@RebornRegistry
+public class ForgePowerManager implements ExternalPowerManager {
+	public ExternalPowerHandler createPowerHandler(TilePowerAcceptor acceptor) {
+		if(!RebornCoreConfig.enableFE) {
+			return null;
+		}
 
-public class ForgePowerManager implements IEnergyStorage {
-
-	TilePowerAcceptor acceptor;
-	@Nullable
-	EnumFacing facing;
-
-	public ForgePowerManager(TilePowerAcceptor acceptor,
-	                         @Nullable
-		                         EnumFacing facing) {
-		this.acceptor = acceptor;
-		this.facing = facing;
+		return new ForgePowerHandler(acceptor);
 	}
 
-	@Override
-	public int receiveEnergy(int maxReceive, boolean simulate) {
-		return acceptor.receiveEnergy(facing, maxReceive, simulate);
+	public boolean isPoweredItem(ItemStack stack) {
+		if(!RebornCoreConfig.enableFE) {
+			return false;
+		}
+
+		return stack.hasCapability(CapabilityEnergy.ENERGY, null);
 	}
 
-	@Override
-	public int extractEnergy(int maxExtract, boolean simulate) {
-		return acceptor.extractEnergy(facing, maxExtract, simulate);
+	public boolean isPoweredTile(TileEntity tileEntity, EnumFacing side) {
+		if(!RebornCoreConfig.enableFE) {
+			return false;
+		}
+
+		return tileEntity.hasCapability(CapabilityEnergy.ENERGY, side);
 	}
 
-	@Override
-	public int getEnergyStored() {
-		return acceptor.getEnergyStored(facing);
+	public void dischargeItem(TilePowerAcceptor powerAcceptor, ItemStack stack) {
+		if(!RebornCoreConfig.enableFE) {
+			return;
+		}
+
+		if(!stack.hasCapability(CapabilityEnergy.ENERGY, null)) {
+			return;
+		}
+
+		double chargeEnergy = Math.min(powerAcceptor.getFreeSpace(), powerAcceptor.getMaxInput()) * RebornCoreConfig.euPerFU;
+		if (chargeEnergy <= 0.0) {
+			return;
+		}
+
+		IEnergyStorage powerItem = stack.getCapability(CapabilityEnergy.ENERGY, null);
+		if (powerItem.getEnergyStored() > 0) {
+			int extracted = powerItem.extractEnergy((int) chargeEnergy, false);
+			powerAcceptor.addEnergy(extracted / RebornCoreConfig.euPerFU);
+		}
 	}
 
-	@Override
-	public int getMaxEnergyStored() {
-		return acceptor.getMaxEnergyStored(facing);
-	}
+	public void chargeItem(TilePowerAcceptor powerAcceptor, ItemStack stack) {
+		if(!RebornCoreConfig.enableFE) {
+			return;
+		}
 
-	@Override
-	public boolean canExtract() {
-		return acceptor.canProvideEnergy(facing);
-	}
+		if(!stack.hasCapability(CapabilityEnergy.ENERGY, null)) {
+			return;
+		}
+		IEnergyStorage powerItem = stack.getCapability(CapabilityEnergy.ENERGY, null);
 
-	@Override
-	public boolean canReceive() {
-		return acceptor.canAcceptEnergy(facing);
-	}
+		int maxReceive = powerItem.receiveEnergy((int)powerAcceptor.getMaxOutput() * RebornCoreConfig.euPerFU, true);
 
-	public void setFacing(
-		@Nullable
-			EnumFacing facing) {
-		this.facing = facing;
+		double maxUse = Math.min((double) (maxReceive / RebornCoreConfig.euPerFU), powerAcceptor.getMaxOutput());
+
+		if (powerAcceptor.getEnergy() >= 0.0 && maxReceive > 0) {
+			powerItem.receiveEnergy((int) powerAcceptor.useEnergy(maxUse) * RebornCoreConfig.euPerFU, false);
+		}
 	}
 }

--- a/src/main/java/reborncore/common/powerSystem/forge/ForgePowerManager.java
+++ b/src/main/java/reborncore/common/powerSystem/forge/ForgePowerManager.java
@@ -70,7 +70,8 @@ public class ForgePowerManager implements ExternalPowerManager {
 			return;
 		}
 
-		if(!stack.hasCapability(CapabilityEnergy.ENERGY, null)) {
+		IEnergyStorage powerItem = stack.getCapability(CapabilityEnergy.ENERGY, null);
+		if(powerItem == null) {
 			return;
 		}
 
@@ -79,10 +80,26 @@ public class ForgePowerManager implements ExternalPowerManager {
 			return;
 		}
 
-		IEnergyStorage powerItem = stack.getCapability(CapabilityEnergy.ENERGY, null);
 		if (powerItem.getEnergyStored() > 0) {
 			int extracted = powerItem.extractEnergy((int) chargeEnergy, false);
 			powerAcceptor.addEnergy(extracted / RebornCoreConfig.euPerFU);
+		}
+	}
+
+	public void dischargeItem(ForgePowerItemManager powerAcceptor, ItemStack stack) {
+		if(!RebornCoreConfig.enableFE) {
+			return;
+		}
+
+		IEnergyStorage powerItem = stack.getCapability(CapabilityEnergy.ENERGY, null);
+		if(powerItem == null) {
+			return;
+		}
+
+		int chargeEnergy = powerAcceptor.receiveEnergy(powerItem.extractEnergy(powerItem.getEnergyStored(), true), true);
+
+		if (chargeEnergy > 0) {
+			powerAcceptor.receiveEnergy(powerItem.extractEnergy(chargeEnergy, false), false);
 		}
 	}
 
@@ -91,10 +108,10 @@ public class ForgePowerManager implements ExternalPowerManager {
 			return;
 		}
 
-		if(!stack.hasCapability(CapabilityEnergy.ENERGY, null)) {
+		IEnergyStorage powerItem = stack.getCapability(CapabilityEnergy.ENERGY, null);
+		if(powerItem == null) {
 			return;
 		}
-		IEnergyStorage powerItem = stack.getCapability(CapabilityEnergy.ENERGY, null);
 
 		int maxReceive = powerItem.receiveEnergy((int)powerAcceptor.getMaxOutput() * RebornCoreConfig.euPerFU, true);
 
@@ -102,6 +119,23 @@ public class ForgePowerManager implements ExternalPowerManager {
 
 		if (powerAcceptor.getEnergy() >= 0.0 && maxReceive > 0) {
 			powerItem.receiveEnergy((int) powerAcceptor.useEnergy(maxUse) * RebornCoreConfig.euPerFU, false);
+		}
+	}
+
+	public void chargeItem(ForgePowerItemManager powerAcceptor, ItemStack stack) {
+		if(!RebornCoreConfig.enableFE) {
+			return;
+		}
+
+		IEnergyStorage powerItem = stack.getCapability(CapabilityEnergy.ENERGY, null);
+		if(powerItem == null) {
+			return;
+		}
+
+		int maxReceive = powerItem.receiveEnergy(powerAcceptor.extractEnergy(powerAcceptor.getEnergyStored(), true), true);
+
+		if (maxReceive > 0) {
+			powerItem.receiveEnergy(powerAcceptor.extractEnergy(maxReceive, false), false);
 		}
 	}
 }

--- a/src/main/java/reborncore/common/powerSystem/forge/ForgePowerManager.java
+++ b/src/main/java/reborncore/common/powerSystem/forge/ForgePowerManager.java
@@ -36,6 +36,7 @@ import net.minecraftforge.energy.IEnergyStorage;
 import reborncore.api.power.ExternalPowerHandler;
 import reborncore.api.power.ExternalPowerManager;
 import reborncore.common.RebornCoreConfig;
+import reborncore.common.powerSystem.ExternalPowerSystems;
 import reborncore.common.powerSystem.TilePowerAcceptor;
 import reborncore.common.registration.RebornRegistry;
 
@@ -66,7 +67,7 @@ public class ForgePowerManager implements ExternalPowerManager {
 	}
 
 	public void dischargeItem(TilePowerAcceptor powerAcceptor, ItemStack stack) {
-		if(!RebornCoreConfig.enableFE) {
+		if(!RebornCoreConfig.enableFE || isOtherPoweredItem(stack)) {
 			return;
 		}
 
@@ -87,7 +88,7 @@ public class ForgePowerManager implements ExternalPowerManager {
 	}
 
 	public void dischargeItem(ForgePowerItemManager powerAcceptor, ItemStack stack) {
-		if(!RebornCoreConfig.enableFE) {
+		if(!RebornCoreConfig.enableFE || isOtherPoweredItem(stack)) {
 			return;
 		}
 
@@ -104,7 +105,7 @@ public class ForgePowerManager implements ExternalPowerManager {
 	}
 
 	public void chargeItem(TilePowerAcceptor powerAcceptor, ItemStack stack) {
-		if(!RebornCoreConfig.enableFE) {
+		if(!RebornCoreConfig.enableFE || isOtherPoweredItem(stack)) {
 			return;
 		}
 
@@ -123,7 +124,7 @@ public class ForgePowerManager implements ExternalPowerManager {
 	}
 
 	public void chargeItem(ForgePowerItemManager powerAcceptor, ItemStack stack) {
-		if(!RebornCoreConfig.enableFE) {
+		if(!RebornCoreConfig.enableFE || isOtherPoweredItem(stack)) {
 			return;
 		}
 
@@ -137,5 +138,14 @@ public class ForgePowerManager implements ExternalPowerManager {
 		if (maxReceive > 0) {
 			powerItem.receiveEnergy(powerAcceptor.extractEnergy(maxReceive, false), false);
 		}
+	}
+
+	/**
+	 * Checks whether the provided tile is considered a powered tile by other power systems already
+	 */
+	private static boolean isOtherPoweredItem(ItemStack stack) {
+		return ExternalPowerSystems.externalPowerHandlerList.stream()
+				.filter(externalPowerManager -> !(externalPowerManager instanceof ForgePowerManager))
+				.anyMatch(externalPowerManager -> externalPowerManager.isPoweredItem(stack));
 	}
 }

--- a/src/main/java/reborncore/common/powerSystem/forge/ForgePowerManager.java
+++ b/src/main/java/reborncore/common/powerSystem/forge/ForgePowerManager.java
@@ -87,23 +87,6 @@ public class ForgePowerManager implements ExternalPowerManager {
 		}
 	}
 
-	public void dischargeItem(ForgePowerItemManager powerAcceptor, ItemStack stack) {
-		if(!RebornCoreConfig.enableFE || isOtherPoweredItem(stack)) {
-			return;
-		}
-
-		IEnergyStorage powerItem = stack.getCapability(CapabilityEnergy.ENERGY, null);
-		if(powerItem == null) {
-			return;
-		}
-
-		int chargeEnergy = powerAcceptor.receiveEnergy(powerItem.extractEnergy(powerItem.getEnergyStored(), true), true);
-
-		if (chargeEnergy > 0) {
-			powerAcceptor.receiveEnergy(powerItem.extractEnergy(chargeEnergy, false), false);
-		}
-	}
-
 	public void chargeItem(TilePowerAcceptor powerAcceptor, ItemStack stack) {
 		if(!RebornCoreConfig.enableFE || isOtherPoweredItem(stack)) {
 			return;

--- a/src/main/java/reborncore/common/util/ItemUtils.java
+++ b/src/main/java/reborncore/common/util/ItemUtils.java
@@ -37,6 +37,7 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.oredict.OreDictionary;
 import reborncore.api.power.IEnergyItemInfo;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 import reborncore.common.recipes.IRecipeInput;
 
 import java.util.ArrayList;
@@ -173,13 +174,13 @@ public class ItemUtils {
 		if (stack.isEmpty()) {
 			return 0.0;
 		}
+
 		if (! (stack.getItem() instanceof IEnergyItemInfo) ) {
 			return 0.0;
 		}
-		IEnergyStorage capEnergy = stack.getCapability(CapabilityEnergy.ENERGY, null);
-		if (capEnergy == null) {
-			return 0.0;
-		}
+
+		IEnergyStorage capEnergy = new ForgePowerItemManager(stack);
+
 		double energy = (double) capEnergy.getEnergyStored();
 		double maxEnergy = (double) capEnergy.getMaxEnergyStored();
 		return energy /  maxEnergy;


### PR DESCRIPTION
This PR resolves the hardcoding issue present in the previous PR in regards to FE support, and makes FE support done completely through ExternalPowerSystems. Also, TR blocks can be configured to not charge FE items, but this has the side effect of not charging TR items since they don't support EU yet.

General list of changes:

* ExternalPowerManager API modified; passes EnumFacing to isPoweredTile query, adds item to item transfer
  * Note: This means that TechReborn-ModCompatibility will need to be updated since these are breaking API changes
* FE support fully moved to an ExternalPowerManager with RebornRegistry
* Uses of getCapability(CapabilityEnergy.ENERGY) replaced with ForgePowerItemManager in StackInfoHUD and ItemUtils
