### PR TITLE
Make ExternalPowerSystems use EntityLivingBase and allow FE support on items to be disabled

### DIFF
--- a/src/main/java/reborncore/client/containerBuilder/builder/ContainerTileInventoryBuilder.java
+++ b/src/main/java/reborncore/client/containerBuilder/builder/ContainerTileInventoryBuilder.java
@@ -33,7 +33,6 @@ import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.inventory.SlotFurnaceFuel;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import org.apache.commons.lang3.Range;
 import org.apache.commons.lang3.tuple.Pair;

--- a/src/main/java/reborncore/client/hud/StackInfoHUD.java
+++ b/src/main/java/reborncore/client/hud/StackInfoHUD.java
@@ -37,7 +37,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;

--- a/src/main/java/reborncore/common/powerSystem/ExternalPowerSystems.java
+++ b/src/main/java/reborncore/common/powerSystem/ExternalPowerSystems.java
@@ -28,7 +28,7 @@
 
 package reborncore.common.powerSystem;
 
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -76,8 +76,8 @@ public class ExternalPowerSystems implements IRegistryFactory {
 				.forEach(externalPowerManager -> externalPowerManager.chargeItem(powerAcceptor, stack));
 	}
 
-	public static void requestEnergyFromArmor(ForgePowerItemManager powerAcceptor, EntityPlayer player) {
-		externalPowerHandlerList.forEach(externalPowerManager -> externalPowerManager.requestEnergyFromArmor(powerAcceptor, player));
+	public static void requestEnergyFromArmor(ForgePowerItemManager powerAcceptor, EntityLivingBase entity) {
+		externalPowerHandlerList.forEach(externalPowerManager -> externalPowerManager.requestEnergyFromArmor(powerAcceptor, entity));
 	}
 
 	@Override

--- a/src/main/java/reborncore/common/powerSystem/PoweredItemContainerProvider.java
+++ b/src/main/java/reborncore/common/powerSystem/PoweredItemContainerProvider.java
@@ -34,6 +34,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.energy.CapabilityEnergy;
 import reborncore.api.power.IEnergyItemInfo;
+import reborncore.common.RebornCoreConfig;
 import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 
 import javax.annotation.Nonnull;
@@ -64,7 +65,7 @@ public class PoweredItemContainerProvider implements ICapabilityProvider {
 
 	@Override
 	public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
-		if (isEnergyItem && capability == CapabilityEnergy.ENERGY) {
+		if (isEnergyItem && capability == CapabilityEnergy.ENERGY && RebornCoreConfig.enableFE) {
 			return true;
 		}
 		return false;
@@ -73,7 +74,7 @@ public class PoweredItemContainerProvider implements ICapabilityProvider {
 	@Nullable
 	@Override
 	public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
-		if (isEnergyItem && capability == CapabilityEnergy.ENERGY) {
+		if (isEnergyItem && capability == CapabilityEnergy.ENERGY && RebornCoreConfig.enableFE) {
 			return CapabilityEnergy.ENERGY.cast(capEnergy);
 		}
 		return null;

--- a/src/main/java/reborncore/common/util/ItemUtils.java
+++ b/src/main/java/reborncore/common/util/ItemUtils.java
@@ -33,7 +33,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.oredict.OreDictionary;
 import reborncore.api.power.IEnergyItemInfo;


### PR DESCRIPTION
This should be the final PR needed to RebornCore to complete the energy refactoring. Some unused imports have been removed, items now respect the FE config option, and ExternalPowerSystems#requestEnergyFromArmor now uses EntityLivingBase.

While the enableFE config option isn't very practical at the moment in regards to items, due to items not yet supporting IC2 power, the further changes needed to support it will now only be needed in TechReborn and TechReborn-ModCompatibility.