### PR TITLE
Add maxPacketsPerTick option

### DIFF
--- a/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
+++ b/src/main/java/reborncore/common/powerSystem/TilePowerAcceptor.java
@@ -54,7 +54,10 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 	public int extraTeir;
 	public double powerChange;
 	public double powerLastTick;
-	public boolean checkOverfill = true; //Set to flase to disable the overfill check.
+	public boolean checkOverfill = true; //Set to false to disable the overfill check.
+	// Some external power systems (EU) support multiple energy packets per tick, this allows machines to possibly emit
+	// multiple packets in a tick. Other power systems such as FE will ignore this option.
+	public int maxPacketsPerTick = 1;
 
 	private List<ExternalPowerHandler> powerManagers;
 
@@ -91,7 +94,11 @@ public abstract class TilePowerAcceptor extends TileLegacyMachineBase implements
 	public void setExtraPowerStoage(double extraPowerStoage) {
 		this.extraPowerStoage = extraPowerStoage;
 	}
-	
+
+	public void setMaxPacketsPerTick(int maxPacketsPerTick) {
+		this.maxPacketsPerTick = maxPacketsPerTick;
+	}
+
 	public double getFreeSpace() {
 		return getMaxPower() - getEnergy();
 	}


### PR DESCRIPTION
First PR in the series to enable multi packet support in transformers. There's only a few lines in this commit, most of the work is in TechReborn and TechReborn-ModCompatibility.