### PR TITLE
Add optional exponential speed scaling option

### DIFF
--- a/src/main/java/reborncore/common/RebornCoreConfig.java
+++ b/src/main/java/reborncore/common/RebornCoreConfig.java
@@ -73,4 +73,10 @@ public class RebornCoreConfig {
 	@ConfigRegistry(config = "misc", key = "Wrench Required", comment = "Wrench required to pick machine. If not wrenched than machine frame will drop instead.")
 	public static boolean wrenchRequired = true;
 
+	@ConfigRegistry(config = "upgrades", key = "Use Exponential Machine Speed Scaling", comment =
+			"Whether to use an alternative, exponential scaling algorithm like IC2.\n" +
+			"With the exponential scaling algorithm (true), processing time will be determined by (1 - OverclockerSpeed)^NumberOfOverclockers.\n" +
+			"Without the algorithm (false), processing time is determined by (1 - OverclockerSpeed*NumberOfOverclockers), with a minimum of 1% processing time."
+	)
+	public static boolean exponentialMachineSpeedScaling = false;
 }

--- a/src/main/java/reborncore/common/tile/TileLegacyMachineBase.java
+++ b/src/main/java/reborncore/common/tile/TileLegacyMachineBase.java
@@ -55,6 +55,7 @@ import reborncore.api.tile.IInventoryProvider;
 import reborncore.api.tile.IUpgrade;
 import reborncore.api.tile.IUpgradeable;
 import reborncore.client.gui.slots.BaseSlot;
+import reborncore.common.RebornCoreConfig;
 import reborncore.common.blocks.BlockMachineBase;
 import reborncore.common.container.RebornContainer;
 import reborncore.common.network.NetworkManager;
@@ -583,10 +584,27 @@ public class TileLegacyMachineBase extends TileEntity implements ITickable, IInv
 
 	@Override
 	public void addSpeedMulti(double amount) {
-		if (speedMultiplier + amount <= 0.99) {
-			speedMultiplier += amount;
+		if(RebornCoreConfig.exponentialMachineSpeedScaling) {
+			// Algorithm: ProcessingTimePercentage = (1 - OverclockerSpeed)^NumberOfOverclockers
+
+			// Convert speed reductions into percentages of original speed.
+			// Example: A 30% speed reduction means 70% of original speed, since 100% - 30% = 70%.
+			double percentSpeedToApply = 1.0 - amount;
+			double percentSpeedCurrent = 1.0 - speedMultiplier;
+
+			// Apply the speed scaling amount to the current percent speed.
+			double newPercentSpeed = percentSpeedToApply*percentSpeedCurrent;
+
+			// Convert back from percentage of original speed to speed reduction amount
+			speedMultiplier = 1.0 - newPercentSpeed;
 		} else {
-			speedMultiplier = 0.99;
+			// Algorithm: ProcessingTimePercentage = (1 - OverclockerSpeed*NumberOfOverclockers)
+
+			if (speedMultiplier + amount <= 0.99) {
+				speedMultiplier += amount;
+			} else {
+				speedMultiplier = 0.99;
+			}
 		}
 	}
 


### PR DESCRIPTION
This adds an option to make overclocker upgrades use an IC2-esque speed scaling instead of the previous scaling algorithm. While it is disabled by default, perhaps in the future it can be made the default algorithm.

Without changing the TR speed/power scale values, this results in a 3x speed with 9.5x power consumption using 4 overclockers, which seems fair. Perhaps on the TechReborn side we could make the upgrade slots stackable, if this is not enough.

New speed and power values with exponential speed scaling:
 * 1 overclocker: 1.33x speed, 1.75x power consumption
 * 2 overclockers: 1.78x speed, 3.06x power consumption
 * 3 overclockers: 2.37x speed, 5.36x power consumption
 * 4 overclockers: 3.16x speed, 9.38x power consumption