### PR TITLE
Fix machine block state not updating when facing north

### DIFF
--- a/src/main/java/reborncore/common/blocks/BlockMachineBase.java
+++ b/src/main/java/reborncore/common/blocks/BlockMachineBase.java
@@ -185,7 +185,7 @@ public abstract class BlockMachineBase extends BaseTileBlock {
 	public IBlockState getStateFromMeta(int meta) {
 		boolean active = false;
 		int facingInt = meta;
-		if (facingInt > 4) {
+		if (facingInt >= 4) {
 			active = true;
 			facingInt = facingInt - 4;
 		}


### PR DESCRIPTION
This change is only visible in multiplayer worlds

Probably fixes https://github.com/TechReborn/TechReborn/issues/1661