### PR TITLE
add support for non-JSON recipe creation, wrapped Ingredients

### DIFF
--- a/src/main/java/reborncore/common/crafting/RebornFluidRecipe.java
+++ b/src/main/java/reborncore/common/crafting/RebornFluidRecipe.java
@@ -20,6 +20,11 @@ public abstract class RebornFluidRecipe extends RebornRecipe {
 		super(type, name);
 	}
 
+	public RebornFluidRecipe(RebornRecipeType<?> type, Identifier name, FluidInstance fluidInstance) {
+		this(type, name);
+		this.fluidInstance = fluidInstance;
+	}
+
 	@Override
 	public void deserialize(JsonObject jsonObject) {
 		super.deserialize(jsonObject);

--- a/src/main/java/reborncore/common/crafting/RebornRecipe.java
+++ b/src/main/java/reborncore/common/crafting/RebornRecipe.java
@@ -68,6 +68,13 @@ public class RebornRecipe implements Recipe<Inventory> {
 		this.name = name;
 	}
 
+	public RebornRecipe(RebornRecipeType<?> type, Identifier name, DefaultedList<RebornIngredient> ingredients, DefaultedList<ItemStack> outputs, int power, int time) {
+		this(type, name);
+		this.ingredients = ingredients;
+		this.outputs = outputs;
+		this.power = power;
+	}
+
 	public void deserialize(JsonObject jsonObject){
 		//Crash if the recipe has all ready been deserialized
 		Validate.isTrue(ingredients.isEmpty());

--- a/src/main/java/reborncore/common/crafting/ingredient/IngredientManager.java
+++ b/src/main/java/reborncore/common/crafting/ingredient/IngredientManager.java
@@ -15,6 +15,7 @@ public class IngredientManager {
 	public static final Identifier STACK_RECIPE_TYPE = new Identifier("reborncore", "stack");
 	public static final Identifier FLUID_RECIPE_TYPE = new Identifier("reborncore", "fluid");
 	public static final Identifier TAG_RECIPE_TYPE = new Identifier("reborncore", "tag");
+	public static final Identifier WRAPPED_RECIPE_TYPE = new Identifier("reborncore", "wrapped");
 
 	private static final HashMap<Identifier, Function<JsonObject, RebornIngredient>> recipeTypes = new HashMap<>();
 
@@ -22,10 +23,11 @@ public class IngredientManager {
 		recipeTypes.put(STACK_RECIPE_TYPE, StackIngredient::deserialize);
 		recipeTypes.put(FLUID_RECIPE_TYPE, FluidIngredient::deserialize);
 		recipeTypes.put(TAG_RECIPE_TYPE, TagIngredient::deserialize);
+		recipeTypes.put(WRAPPED_RECIPE_TYPE, WrappedIngredient::deserialize);
 	}
 
 	public static RebornIngredient deserialize(@Nullable JsonElement jsonElement) {
-		if(jsonElement == null || !jsonElement.isJsonObject()){
+		if(jsonElement == null || !jsonElement.isJsonObject()) {
 			throw new JsonParseException("ingredient must be a json object");
 		}
 
@@ -35,16 +37,18 @@ public class IngredientManager {
 		//TODO find a better way to do this.
 		if (json.has("fluid")) {
 			recipeTypeIdent = FLUID_RECIPE_TYPE;
-		} else if (json.has("tag")){
+		} else if (json.has("tag")) {
 			recipeTypeIdent = TAG_RECIPE_TYPE;
+		} else if (json.has("wrapped")) {
+			recipeTypeIdent = WRAPPED_RECIPE_TYPE;
 		}
 
-		if(json.has("type")){
+		if(json.has("type")) {
 			recipeTypeIdent = new Identifier(JsonHelper.getString(json, "type"));
 		}
 
 		Function<JsonObject, RebornIngredient> recipeTypeFunction = recipeTypes.get(recipeTypeIdent);
-		if(recipeTypeFunction == null){
+		if(recipeTypeFunction == null) {
 			throw new JsonParseException("No recipe type found for " + recipeTypeIdent.toString());
 		}
 		return recipeTypeFunction.apply(json);

--- a/src/main/java/reborncore/common/crafting/ingredient/WrappedIngredient.java
+++ b/src/main/java/reborncore/common/crafting/ingredient/WrappedIngredient.java
@@ -1,0 +1,63 @@
+package reborncore.common.crafting.ingredient;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+import reborncore.mixin.extensions.IngredientExtensions;
+
+import java.util.List;
+
+public class WrappedIngredient extends RebornIngredient {
+    private Ingredient wrapped;
+
+    public WrappedIngredient() {
+        super(IngredientManager.WRAPPED_RECIPE_TYPE);
+    }
+
+    public WrappedIngredient(Ingredient wrapped) {
+        this();
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public boolean test(ItemStack itemStack) {
+        return wrapped.test(itemStack);
+    }
+
+    @Override
+    public Ingredient getPreview() {
+        return wrapped;
+    }
+
+    @Override
+    public List<ItemStack> getPreviewStacks() {
+        return ((IngredientExtensions) (Object) wrapped).getIngredientStacks();
+    }
+
+    @Override
+    protected JsonObject toJson() {
+        if (wrapped.toJson() instanceof JsonObject) {
+            return (JsonObject) wrapped.toJson();
+        }
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.add("options", wrapped.toJson());
+        return jsonObject;
+    }
+
+    @Override
+    public int getCount() {
+        return ((IngredientExtensions) (Object) wrapped).getIngredientStacks().size();
+    }
+
+    public static RebornIngredient deserialize(JsonObject jsonObject) {
+        Ingredient underlying;
+        if (jsonObject.has("options") && jsonObject.get("options") instanceof JsonArray) {
+            underlying = Ingredient.fromJson(jsonObject.get("options"));
+        }
+        else {
+            underlying = Ingredient.fromJson(jsonObject);
+        }
+        return new WrappedIngredient(underlying);
+    }
+}

--- a/src/main/java/reborncore/mixin/common/MixinIngredient.java
+++ b/src/main/java/reborncore/mixin/common/MixinIngredient.java
@@ -1,0 +1,20 @@
+package reborncore.mixin.common;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import reborncore.mixin.extensions.IngredientExtensions;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Mixin(Ingredient.class)
+public class MixinIngredient implements IngredientExtensions {
+    @Shadow private ItemStack[] stackArray;
+
+    @Override
+    public List<ItemStack> getIngredientStacks() {
+        return Arrays.asList(stackArray);
+    }
+}

--- a/src/main/java/reborncore/mixin/extensions/IngredientExtensions.java
+++ b/src/main/java/reborncore/mixin/extensions/IngredientExtensions.java
@@ -1,0 +1,10 @@
+package reborncore.mixin.extensions;
+
+import net.minecraft.item.ItemStack;
+
+import java.util.List;
+
+//because Ingredient.getStackArray() is client-only
+public interface IngredientExtensions {
+    List<ItemStack> getIngredientStacks();
+}

--- a/src/main/resources/reborncore.common.mixins.json
+++ b/src/main/resources/reborncore.common.mixins.json
@@ -10,7 +10,8 @@
     "MixinSlot",
     "MixinBucketItem",
     "MixinWorldSaveHandler",
-    "MixinItemStack"
+    "MixinItemStack",
+    "MixinIngredient"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Required PR for proper implementation of [TechReborn #1851](https://github.com/TechReborn/TechReborn/pull/1851). Removes the necessity of all of the LibCD PR's ugly recipe hacks.

- adds constructors for `RebornRecipe` and `RebornFluidRecipe` which call to default ctor and allow explicit declaration of recipe parameters.
- adds `WrappedIngredient` which wraps a vanilla Ingredient as a `RebornIngredient`.
- adds mixin on `Ingredient` to be able to access item stack array on dedicated server due to ProGuard method stripping.