### PR TITLE
impl CustomOutputRecipe for libcd support

### DIFF
--- a/src/main/java/io/github/cottonmc/libcd/api/CustomOutputRecipe.java
+++ b/src/main/java/io/github/cottonmc/libcd/api/CustomOutputRecipe.java
@@ -1,0 +1,13 @@
+package io.github.cottonmc.libcd.api;
+
+import net.minecraft.item.Item;
+
+import java.util.Collection;
+
+/**
+ * A recipe that has output behavior that cannot be described by just the Recipe#getOutput() method.
+ * Used for RecipeTweaker remove-by-output code.
+ */
+public interface CustomOutputRecipe {
+	Collection<Item> getOutputItems();
+}

--- a/src/main/java/reborncore/common/crafting/RebornRecipe.java
+++ b/src/main/java/reborncore/common/crafting/RebornRecipe.java
@@ -32,9 +32,11 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.Dynamic;
 import com.mojang.datafixers.types.JsonOps;
+import io.github.cottonmc.libcd.api.CustomOutputRecipe;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.datafixers.NbtOps;
 import net.minecraft.inventory.Inventory;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.recipe.Recipe;
@@ -53,10 +55,12 @@ import reborncore.common.crafting.ingredient.RebornIngredient;
 import reborncore.common.util.DefaultedListCollector;
 import reborncore.common.util.serialization.SerializationUtil;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-public class RebornRecipe implements Recipe<Inventory> {
+public class RebornRecipe implements Recipe<Inventory>, CustomOutputRecipe {
 
 	private final RebornRecipeType<?> type;
 	private final Identifier name;
@@ -246,5 +250,14 @@ public class RebornRecipe implements Recipe<Inventory> {
 	void makeDummy() {
 		this.ingredients.add(new DummyIngredient());
 		this.dummy = true;
+	}
+
+	@Override
+	public Collection<Item> getOutputItems() {
+		List<Item> items = new ArrayList<>();
+		for (ItemStack stack : outputs) {
+			items.add(stack.getItem());
+		}
+		return items;
 	}
 }


### PR DESCRIPTION
Prevents `UnsupportedOperationException` being thrown by LibCD remove-for-output behavior.