### PR TITLE
Add comparator output support for machines

### DIFF
--- a/src/main/java/reborncore/common/blocks/BlockMachineBase.java
+++ b/src/main/java/reborncore/common/blocks/BlockMachineBase.java
@@ -33,6 +33,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.InventoryProvider;
 import net.minecraft.block.Material;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.container.Container;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -244,5 +245,15 @@ public abstract class BlockMachineBase extends BaseBlockEntityProvider implement
 			((MachineBaseBlockEntity) blockEntity).onBreak(world, playerEntity, blockPos, blockState);
 		}
 		super.onBreak(world, blockPos, blockState, playerEntity);
+	}
+
+	@Override
+	public boolean hasComparatorOutput(BlockState state) {
+		return true;
+	}
+
+	@Override
+	public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
+		return Container.calculateComparatorOutput(getInventory(state, world, pos));
 	}
 }

--- a/src/main/java/reborncore/common/powerSystem/PowerAcceptorBlockEntity.java
+++ b/src/main/java/reborncore/common/powerSystem/PowerAcceptorBlockEntity.java
@@ -36,6 +36,7 @@ import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MathHelper;
 import reborncore.api.IListInfoProvider;
 import reborncore.common.blockentity.MachineBaseBlockEntity;
 import reborncore.common.util.StringUtils;
@@ -44,6 +45,7 @@ import team.reborn.energy.EnergySide;
 import team.reborn.energy.EnergyStorage;
 import team.reborn.energy.EnergyTier;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public abstract class PowerAcceptorBlockEntity extends MachineBaseBlockEntity implements EnergyStorage, IListInfoProvider // TechReborn
@@ -401,6 +403,22 @@ public abstract class PowerAcceptorBlockEntity extends MachineBaseBlockEntity im
 		}
 
 		super.addInfo(info, isReal, hasData);
+	}
+
+	/**
+	 * Calculates the comparator output of a powered BE with the formula
+	 * {@code ceil(blockEntity.getEnergy() * 15.0 / storage.getMaxPower())}.
+	 *
+	 * @param blockEntity the powered BE
+	 * @return the calculated comparator output or 0 if {@code blockEntity} is not a {@code PowerAcceptorBlockEntity}
+	 */
+	public static int calculateComparatorOutputFromEnergy(@Nullable BlockEntity blockEntity) {
+		if (blockEntity instanceof PowerAcceptorBlockEntity) {
+			PowerAcceptorBlockEntity storage = (PowerAcceptorBlockEntity) blockEntity;
+			return MathHelper.ceil(storage.getEnergy() * 15.0 / storage.getMaxPower());
+		} else {
+			return 0;
+		}
 	}
 
 }

--- a/src/main/java/reborncore/common/powerSystem/PowerAcceptorBlockEntity.java
+++ b/src/main/java/reborncore/common/powerSystem/PowerAcceptorBlockEntity.java
@@ -263,6 +263,7 @@ public abstract class PowerAcceptorBlockEntity extends MachineBaseBlockEntity im
 		if(checkOverfill){
 			this.energy = Math.max(Math.min(energy, getMaxPower()), 0);
 		}
+		markDirty();
 	}
 
 	public void setEnergy(double energy) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
     "reborncore.client.mixins.json",
     "reborncore.common.mixins.json"
   ],
-  "requires": {
+  "depends": {
     "fabricloader": ">=0.6.3",
     "fabric": "*"
   },


### PR DESCRIPTION
See also TechReborn/TechReborn#1901.

- `BlockMachineBase` uses the regular calculation method for containers
- Added an energy-based calculation to `PowerAcceptorBlockEntity`  (used in the TechReborn PR)
- Added a `markDirty()` call to PowerAcceptorBlockEntity.setStored()
  - Calling `markDirty()` also updates the comparators next to the block, which is needed for energy-based comparator output.
- Updated `requires` to `depends` in the fabric.mod.json