### PR TITLE
Localized the energy stored

### DIFF
--- a/src/main/resources/assets/reborncore/lang/en_us.json
+++ b/src/main/resources/assets/reborncore/lang/en_us.json
@@ -7,6 +7,7 @@
 	"reborncore.tooltip.energy.outputRate": "Output Rate",
 	"reborncore.tooltip.energy.tier": "Tier",
 	"reborncore.tooltip.energy.change": "Energy Change",
+	"reborncore.tooltip.energy": "Energy Stored",
 	
 	"reborncore.gui.heat": "Heat",
 	"reborncore.gui.missingmultiblock": "Incomplete Multiblock",


### PR DESCRIPTION
Currently shows up when hovering over a UI energy bar as the unlocalized name for the energy stored, this resolves this.