### PR TITLE
MachineBaseBlockEntity: Don't rely on getTank() being non-null

### DIFF
--- a/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
+++ b/src/main/java/reborncore/common/blockentity/MachineBaseBlockEntity.java
@@ -239,10 +239,8 @@ public class MachineBaseBlockEntity extends BlockEntity implements Tickable, IUp
 				slotConfiguration = new SlotConfiguration(getOptionalInventory().get());
 			}
 		}
-		if (tagCompound.contains("fluidConfig") && getTank() != null) {
+		if (tagCompound.contains("fluidConfig")) {
 			fluidConfiguration = new FluidConfiguration(tagCompound.getCompound("fluidConfig"));
-		} else if (getTank() != null && fluidConfiguration == null) {
-			fluidConfiguration = new FluidConfiguration();
 		}
 		if (tagCompound.contains("redstoneConfig")) {
 			redstoneConfiguration.refreshCache();


### PR DESCRIPTION
This fixes FluidConfiguration not surviving a server restart.

Every machine block subclass with a tank calls `super.fromTag()`
first before doing its own deserialization, however only after
the subclass `fromTag()` code has run, can a Tank instance possibly
be instantiated. This means that `getTank() != null` in
`MachineBaseBlockEntity#fromTag` will always evaluate to false.

For loading the `FluidConfiguration` however we don't have to care
about the tank instance, because a subclass without tank would
never have resulted in a `FluidConfiguration` being written to
the NBT in the first place. In case a tank does exist but the
NBT contains no `FluidConfiguration`, `#onLoad` will take care of
creating a default instance.

I was considering a couple different approaches, including having subclasses of MachineBaseBlockEntity "statically" communicate whether they are tank-bearing (via a simple overridden bool method), but I think ultimately this is the least invasive approach.  
Server restart is basically the same as saving and later loading the game in single player, so if you always played in multiplayer, you would hardly run into this problem.