### PR TITLE
FluidUtil: Reset source tank fluid type once it is drained

### DIFF
--- a/src/main/java/reborncore/common/fluid/FluidUtil.java
+++ b/src/main/java/reborncore/common/fluid/FluidUtil.java
@@ -82,6 +82,10 @@ public class FluidUtil {
 			}
 			source.setFluidAmount(source.getFluidAmount().subtract(transferAmount));
 			destination.setFluidInstance(fluidInstance);
+
+			if (source.getFluidAmount().equals(FluidValue.EMPTY)) {
+				source.setFluid(Fluids.EMPTY);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes tanks not pulling in different fluid types via auto-transfer after they have been drained.

Personally I'd like it if tanks had some sort of `take(FluidValue amount)` method that returns the actual value extracted (min(amount, contents)) and automatically sets the type to empty.